### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,24 @@ Are you ready to get started?
 ### Module 1
 
 How to build a hello world application on NextJS and deploy it using Vercel ->
-[Get started](/module1/index.md)
+[Get started](/module1/README.md)
 
 ### Module 2
 
 How to connect your frontend application to OpenAI APIs and passing custom prompts ->
-[Get started](/module2/index.md)
+[Get started](/module2/README.md)
 
 ### Module 3
 
 Enabling Plagiarism checker ->
-[Get started](/module3/index.md)
+[Get started](/module3/README.md)
 
 ### Module 4
 
 Setting up Twitter Authentication and open graph preview ->
-[Get started](/module4/index.md)
+[Get started](/module4/README.md)
 
 ### Module 5 (Optional)
 
 Setting up image generator via custom AI tuning using AWS Sagemaker ->
-[Get started](/module5/index.md)
+[Get started](/module5/README.md)

--- a/module1/README.md
+++ b/module1/README.md
@@ -356,19 +356,20 @@ If you wanted to deploy this application using AWS services, you would have had 
 ### Setting Up Vercel
 
 1. Go to https://vercel.com/
-2. Click on the `Sign Up` button
-3. Select `Hobby`. Enter your name. Click Continue
-4. Click `Continue with GitHub`
-5. Authorize Vercel to connect to your GitHub account <br/>
+1. Click on the `Sign Up` button
+1. Select `Hobby`. Enter your name. Click Continue
+1. Click `Continue with GitHub`
+1. Authorize Vercel to connect to your GitHub account <br/>
    Make sure to configure the permissions correctly
    ![github authorization](content/github-authorization.png)
-6. Click `Import` next to your Git repository
-7. Click on the `Build and Output Settings` accordion.
-8. Under `Build Command`, enable the override toggle and enter `pnpm build`
-9. Under `Install Command`, enable the override toggle and enter `pnpm install`
+1. Click `Import` next to your Git repository
+1. Ensure `Framework Preset` is `Next.js`
+1. Click on the `Build and Output Settings` accordion.
+1. Under `Build Command`, enable the override toggle and enter `pnpm build`
+1. Under `Install Command`, enable the override toggle and enter `pnpm install`
    ![vercel-settings](content/vercel-settings.png)
-10. Click `Deploy`
-11. Once the application has been deployed, click on the image below `Continue to Dashboard` to view your deployed application<br/>
+1. Click `Deploy`
+1. Once the application has been deployed, click on the image below `Continue to Dashboard` to view your deployed application<br/>
     ![deployed-app](content/deployed-app.png)
 
 Congratulations you have now completed Module1 and ready to move on to the second module. Your completed app should look like this: [Module1-final demo](final-demo/latency-workshop-app/). <br/>


### PR DESCRIPTION
module 1: ensure vercel framework is next.js
my framework was set to 'Other' and got 404 on vercel

update link to README correctly on the root README

also update the README list numbering (so we can add an item without having to re-number everything)